### PR TITLE
Fixed problem with  relative URL redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "semantic-release": "semantic-release"
   },
   "peerDependencies": {
-    "next": ">=12.0.0"
+    "next": ">=12.0.9"
   },
   "devDependencies": {
     "@babel/core": "^7.16.10",
@@ -45,7 +45,7 @@
     "fetch-mock": "^9.11.0",
     "husky": "^7.0.4",
     "jest": "^27.4.7",
-    "next": "^12.0.8",
+    "next": "^12.0.9",
     "prettier": "^2.5.1",
     "query-string": "^7.1.0",
     "semantic-release": "^19.0.2",

--- a/src/__tests__/middleware.spec.ts
+++ b/src/__tests__/middleware.spec.ts
@@ -1,5 +1,6 @@
 import { makeMiddleware } from '../middleware'
 import { NextRequest, NextResponse, NextFetchEvent } from 'next/server'
+import { NextURL } from 'next/dist/server/web/next-url'
 
 jest.mock('next/server', () => ({
   NextResponse: { rewrite: jest.fn() }
@@ -11,10 +12,9 @@ const makeRequest = (
   pathname = '/base'
 ): NextRequest =>
   ({
-    nextUrl: {
-      searchParams,
-      pathname
-    }
+    nextUrl: new NextURL(
+      `http://localhost:3000${pathname}?${searchParams.toString()}`
+    )
   } as NextRequest)
 
 describe('makeMiddleware', () => {
@@ -43,7 +43,9 @@ describe('makeMiddleware', () => {
     })
     test('parameters are pathified', () => {
       middleware(makeRequest(new URLSearchParams({ page: '2' })), event)
-      expect(NextResponse.rewrite).toBeCalledWith('/base/page-2')
+      expect(NextResponse.rewrite).toBeCalledWith(
+        new NextURL('http://localhost:3000/base/page-2?page=2')
+      )
     })
     test('if there is no querystring, it will not be rewritten', () => {
       middleware(makeRequest(new URLSearchParams({})), event)
@@ -58,14 +60,18 @@ describe('makeMiddleware', () => {
         makeRequest(new URLSearchParams({ page: '2', sort: 'postedAt' })),
         event
       )
-      expect(NextResponse.rewrite).toBeCalledWith('/base/page-2')
+      expect(NextResponse.rewrite).toBeCalledWith(
+        new NextURL('http://localhost:3000/base/page-2?page=2&sort=postedAt')
+      )
     })
     test('no duplicate slashes, even with trailing slashes', () => {
       middleware(
         makeRequest(new URLSearchParams({ page: '2' }), '/base/'),
         event
       )
-      expect(NextResponse.rewrite).toBeCalledWith('/base/page-2')
+      expect(NextResponse.rewrite).toBeCalledWith(
+        new NextURL('http://localhost:3000/base/page-2?page=2')
+      )
     })
   })
 
@@ -75,7 +81,9 @@ describe('makeMiddleware', () => {
     })
     test('the path will be replaced', () => {
       middleware(makeRequest(new URLSearchParams({ page: '2' })), event)
-      expect(NextResponse.rewrite).toBeCalledWith('/base/page-2')
+      expect(NextResponse.rewrite).toBeCalledWith(
+        new NextURL('http://localhost:3000/base/page-2?page=2')
+      )
     })
   })
 })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,8 +16,9 @@ export const makeMiddleware = (option: {
       .join('/')
     if (!params) return
 
-    return NextResponse.rewrite(
-      `${req.nextUrl.pathname}/${params}`.replace(/\/\//, '/')
-    )
+    const url = req.nextUrl.clone()
+    url.pathname = (url.pathname + `/${params}`).replace(/\/\//, '/')
+
+    return NextResponse.rewrite(url)
   }
 }


### PR DESCRIPTION
It causes query string parameters to be dropped on the client side.

I had to bump "next" version requirement to 12.0.9 because that's when they introduced the `clone` method to the `NextURL` object.